### PR TITLE
Fix the SMA back test ret cmp

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -14,6 +14,7 @@ from test_portfolio import PortfolioTest
 from test_position import PositionTest
 from test_ser_deser import SerializerTest
 from test_talib_wrapper import TALibSMATest
+from test_cmp_functional_backtest import TestCompareWithFunctionalBacktest
 
 def suite():
     test_suite = unittest.TestSuite()
@@ -31,6 +32,7 @@ def suite():
     test_suite.addTest(unittest.makeSuite(PositionTest))
     test_suite.addTest(unittest.makeSuite(SerializerTest))
     test_suite.addTest(unittest.makeSuite(TALibSMATest))
+    test_suite.addTest(unittest.makeSuite(TestCompareWithFunctionalBacktest))
     return test_suite
 
 mySuit = suite()


### PR DESCRIPTION
```
modified:   tests/test_cmp_functional_backtest.py
modified:   tests/test_suite.py
```

Fixed, the test pass now, and also mean at least in this test the event framework backtesting result match with independent testing result.
