### PR TITLE
Feature/data frame

### DIFF
--- a/algotrader/app/backtest_runner.py
+++ b/algotrader/app/backtest_runner.py
@@ -49,7 +49,8 @@ class BacktestRunner(Application):
 def main():
     config = Config(
         load_from_yaml("../../config/backtest.yaml"),
-        load_from_yaml("../../config/down2%.yaml"))
+        load_from_yaml("../../config/mvg_avg_force.yaml"))
+        # load_from_yaml("../../config/down2%.yaml"))
 
     app_context = ApplicationContext(config=config)
 

--- a/algotrader/provider/datastore/mongodb.py
+++ b/algotrader/provider/datastore/mongodb.py
@@ -83,7 +83,7 @@ class MongoDBDataStore(SimpleDataStore):
         return DataStore.Mongo
 
     def save(self, obj):
-        logger.info("[%s] saving %s" % (self.__class__.__name__, obj))
+        logger.debug("[%s] saving %s" % (self.__class__.__name__, obj))
         id = get_model_id(obj)
         packed_data = protobuf_to_dict(obj)
         t = type(obj)

--- a/algotrader/provider/feed/pandas_db.py
+++ b/algotrader/provider/feed/pandas_db.py
@@ -25,7 +25,7 @@ class PandaDBDataFeed(PandasDataFeed):
         for sub_req in sub_reqs:
             inst = insts[sub_req.inst_id]
             frame_id = build_bar_frame_id(inst_id=inst.inst_id, size=sub_req.bar_size, provider_id=provider_id)
-            algo_df = self.app_context.inst_data_mgr.get_frame(frame_id)
+            algo_df = self.app_context.inst_data_mgr.get_frame(frame_id, provider_id=provider_id, inst_id=inst.inst_id)
             df = algo_df.to_pd_dataframe()
             df['InstId'] = sub_req.inst_id
             df['ProviderId'] = sub_req.md_provider_id

--- a/algotrader/provider/feed/pandas_db.py
+++ b/algotrader/provider/feed/pandas_db.py
@@ -3,6 +3,8 @@ import pandas as pd
 from algotrader import Context
 from algotrader.provider.feed import Feed, PandasDataFeed
 from algotrader.utils.market_data import build_bar_frame_id
+from algotrader.trading.series import Series
+from algotrader.trading.data_frame import DataFrame
 
 
 class PandaDBDataFeed(PandasDataFeed):
@@ -14,6 +16,7 @@ class PandaDBDataFeed(PandasDataFeed):
         super(PandaDBDataFeed, self).__init__(datetime_as_index=True)
 
     def _start(self, app_context: Context) -> None:
+        self.store = app_context.get_data_store()
         self.provider_id = self._get_feed_config("provider_id")
 
     def id(self):
@@ -25,13 +28,39 @@ class PandaDBDataFeed(PandasDataFeed):
         for sub_req in sub_reqs:
             inst = insts[sub_req.inst_id]
             frame_id = build_bar_frame_id(inst_id=inst.inst_id, size=sub_req.bar_size, provider_id=provider_id)
-            algo_df = self.app_context.inst_data_mgr.get_frame(frame_id, provider_id=provider_id, inst_id=inst.inst_id)
-            df = algo_df.to_pd_dataframe()
+            # algo_df = self.app_context.inst_data_mgr.get_frame(frame_id, provider_id=provider_id, inst_id=inst.inst_id)
+            # df = algo_df.to_pd_dataframe()
+            df = self._get_frame(frame_id).to_pd_dataframe()
             df['InstId'] = sub_req.inst_id
             df['ProviderId'] = sub_req.md_provider_id
             df['BarSize'] = sub_req.bar_size
             dfs.append(df)
         return dfs
 
+    def _get_series(self, key):
+        if type(key) != str:
+            raise AssertionError()
 
+        if self.store.obj_exist('series', key):
+            proto_series = self.store.load_one('series', key)
+            series = Series.from_proto_series(proto_series)
+            return series
+
+        else:
+            raise RuntimeError("No series %s in database!" % key)
+
+
+    def _get_frame(self, key):
+        if type(key) != str:
+            raise AssertionError()
+
+        if self.store.obj_exist('frame', key):
+            proto_frame = self.store.load_one('frame', key)
+            series_list = [self._get_series(series_id) for series_id in proto_frame.series_id_list]
+            series_dict = {series.col_id: series for series in series_list}
+            frame = DataFrame.from_series_dict(series_dict)
+            return frame
+
+        else:
+            raise RuntimeError("No dataframe %s in database!" % key)
 

--- a/algotrader/strategy/down_2pct_strategy.py
+++ b/algotrader/strategy/down_2pct_strategy.py
@@ -16,8 +16,8 @@ class Down2PctStrategy(Strategy):
         self.qty = self._get_stg_config("qty", default=1)
 
         self.close = self.app_context.inst_data_mgr.get_series(
-            "Bar.%s.close.Time.86400" % app_context.config.get_app_config("instrumentIds")[0])
-        self.close.start(app_context)
+            "Bar.%s.Time.86400.Yahoo.close" % app_context.config.get_app_config("instrumentIds")[0], transient=True)
+        # self.close.start(app_context)
 
         # decorate the simple function with extra attribute so that the Series as functor can retrieve
         roc_function = talib_function(periods=1, name='roc')(talib.ROC) # construct a functor

--- a/algotrader/strategy/down_2pct_strategy.py
+++ b/algotrader/strategy/down_2pct_strategy.py
@@ -4,6 +4,7 @@ from algotrader import Context
 from algotrader.model.trade_data_pb2 import *
 from algotrader.strategy import Strategy
 from algotrader.technical.talib_wrapper import talib_function
+from algotrader.utils.market_data import build_bar_frame_id, build_series_id, M1, D1
 
 
 class Down2PctStrategy(Strategy):
@@ -15,8 +16,12 @@ class Down2PctStrategy(Strategy):
     def _start(self, app_context: Context) -> None:
         self.qty = self._get_stg_config("qty", default=1)
 
-        self.close = self.app_context.inst_data_mgr.get_series(
-            "Bar.%s.Time.86400.Yahoo.close" % app_context.config.get_app_config("instrumentIds")[0], transient=True)
+        inst_id = app_context.config.get_app_config("instrumentIds")[0]
+        close_key = build_series_id(inst_id, D1, "Yahoo", 'close')
+        self.close = self.app_context.inst_data_mgr.get_series(close_key, transient=True)
+
+        # self.close = self.app_context.inst_data_mgr.get_series(
+        #     "Bar.%s.Time.86400.Yahoo.close" % app_context.config.get_app_config("instrumentIds")[0], transient=True)
         # self.close.start(app_context)
 
         # decorate the simple function with extra attribute so that the Series as functor can retrieve

--- a/algotrader/strategy/down_2pct_strategy.py
+++ b/algotrader/strategy/down_2pct_strategy.py
@@ -4,6 +4,7 @@ from algotrader import Context
 from algotrader.model.trade_data_pb2 import *
 from algotrader.strategy import Strategy
 from algotrader.technical.talib_wrapper import talib_function
+from algotrader.utils.market_data import build_bar_frame_id, build_series_id, M1, D1
 
 
 class Down2PctStrategy(Strategy):
@@ -15,8 +16,13 @@ class Down2PctStrategy(Strategy):
     def _start(self, app_context: Context) -> None:
         self.qty = self._get_stg_config("qty", default=1)
 
-        self.close = self.app_context.inst_data_mgr.get_series(
-            "Bar.%s.close.Time.86400" % app_context.config.get_app_config("instrumentIds")[0])
+        bt_provider = self.app_context.config.config['Application']['type']
+
+        inst_id = app_context.config.get_app_config("instrumentIds")[0]
+        close_key = build_series_id(inst_id, D1, bt_provider, 'close')
+        self.close = self.app_context.inst_data_mgr.get_series(close_key)
+        # self.close = self.app_context.inst_data_mgr.get_series(
+        #     "Bar.%s.close.Time.86400" % app_context.config.get_app_config("instrumentIds")[0])
         self.close.start(app_context)
 
         # decorate the simple function with extra attribute so that the Series as functor can retrieve

--- a/algotrader/trading/data_frame.py
+++ b/algotrader/trading/data_frame.py
@@ -421,3 +421,6 @@ class DataFrame(Subscribable, Startable, Monad, Monoid):
 
     def __ne__(self, other):
         return not self.__eq__(other)
+
+    def get(self, indexes=None, columns=None, as_list=False, as_dict=False):
+        return self.rc_df.get(indexes, columns, as_list, as_dict)

--- a/algotrader/trading/data_frame.py
+++ b/algotrader/trading/data_frame.py
@@ -18,7 +18,9 @@ from algotrader.trading.subscribable import Subscribable
 class DataFrame(Subscribable, Startable, Monad, Monoid):
     def __init__(self, df_id=None, provider_id=None, inst_id=None, parent_df_id=None,
                  columns=None, func=None,
-                 update_mode: UpdateMode = UpdateMode.ACTIVE_SUBSCRIBE, *args, **kwargs):
+                 update_mode: UpdateMode = UpdateMode.ACTIVE_SUBSCRIBE,
+                 transient=False,
+                 *args, **kwargs):
         """
         Default Ctor, with protobuf obj pls construct by from ctor
         :param df_id:
@@ -28,6 +30,7 @@ class DataFrame(Subscribable, Startable, Monad, Monoid):
         :param columns:
         :param func:
         :param update_mode:
+        :param transient:
         :param args:
         :param kwargs:
         """
@@ -40,9 +43,7 @@ class DataFrame(Subscribable, Startable, Monad, Monoid):
         self.parent_df_id = parent_df_id
         self.func = func
         self.update_mode = update_mode
-
-
-
+        self.transient = transient
 
 
     def _start(self, app_context = None):
@@ -215,6 +216,7 @@ class DataFrame(Subscribable, Startable, Monad, Monoid):
         df.inst_id = series.inst_id
 
         df.rc_df = DataFrame.pd_df_to_rc_df(pd_df)
+        df.transient = False
         return df
 
     @classmethod

--- a/algotrader/trading/data_frame.py
+++ b/algotrader/trading/data_frame.py
@@ -207,7 +207,16 @@ class DataFrame(Subscribable, Startable, Monad, Monoid):
         """
         df = cls()
         df.series_dict = series_dict
-        pd_df = pd.DataFrame(data={series.col_id: series.to_pd_series() for series in series_dict.values()})
+
+        # check if all the series came from single inst id, if then we use col_id as column
+        # else, different inst's close (with same col_id ) may join together into single df
+        # se in this case we will use the unique series_id instead
+
+        num_distinct_inst_id = len({series.inst_id for series in series_dict.values()})
+        if num_distinct_inst_id > 1:
+            pd_df = pd.DataFrame(data={series.series_id: series.to_pd_series() for series in series_dict.values()})
+        else:
+            pd_df = pd.DataFrame(data={series.col_id: series.to_pd_series() for series in series_dict.values()})
 
         series = next(iter(series_dict.values()))
 

--- a/algotrader/trading/data_frame.py
+++ b/algotrader/trading/data_frame.py
@@ -208,16 +208,7 @@ class DataFrame(Subscribable, Startable, Monad, Monoid):
         df = cls()
         df.series_dict = series_dict
 
-        # check if all the series came from single inst id, if then we use col_id as column
-        # else, different inst's close (with same col_id ) may join together into single df
-        # se in this case we will use the unique series_id instead
-
-        num_distinct_inst_id = len({series.inst_id for series in series_dict.values()})
-        if num_distinct_inst_id > 1:
-            pd_df = pd.DataFrame(data={series.series_id: series.to_pd_series() for series in series_dict.values()})
-        else:
-            pd_df = pd.DataFrame(data={series.col_id: series.to_pd_series() for series in series_dict.values()})
-
+        pd_df = pd.DataFrame(data={key: series.to_pd_series() for key, series in series_dict.items()})
         series = next(iter(series_dict.values()))
 
         df.df_id = series.df_id
@@ -310,7 +301,17 @@ class DataFrame(Subscribable, Startable, Monad, Monoid):
     @classmethod
     def from_proto_frame(cls, bundle: Frame, app_context):
         series_list = [app_context.inst_data_mgr.get_series(series_id) for series_id in bundle.series_id_list]
-        series_dict = {series.col_id: series for series in series_list}
+
+        # check if all the series came from single inst id, if then we use col_id as column
+        # else, different inst's close (with same col_id ) may join together into single df
+        # se in this case we will use the unique series_id instead
+        num_distinct_inst_id = len({series.inst_id for series in series_list})
+        if num_distinct_inst_id > 1:
+            series_dict = {series.series_id: series for series in series_list}
+        else:
+            series_dict = {series.col_id: series for series in series_list}
+
+        # series_dict = {series.col_id: series for series in series_list}
         return DataFrame.from_series_dict(series_dict)
 
     def to_list_of_lists(self, cols_orders: list = None):

--- a/algotrader/trading/data_frame.py
+++ b/algotrader/trading/data_frame.py
@@ -371,7 +371,8 @@ class DataFrame(Subscribable, Startable, Monad, Monoid):
             for col, val in values.items():
                 if col in self.series_dict.keys():
                     series = self.series_dict[col]
-                    series.add(indexes, val)
+                    series.append_rows(indexes, val)
+                    # series.add(indexes, val)
 
         self.notify_downstream(None)
 

--- a/algotrader/trading/data_frame.py
+++ b/algotrader/trading/data_frame.py
@@ -375,9 +375,11 @@ class DataFrame(Subscribable, Startable, Monad, Monoid):
 
 
     def append_row(self, index, value, new_cols=True):
-        if index in self.rc_df.index and \
-            self.app_context is not None and \
-                self.app_context.config.config['Application']['type'] == Application.BackTesting:
+        # if index in self.rc_df.index and \
+        #     self.app_context is not None and \
+        #         self.app_context.config.config['Application']['type'] == Application.BackTesting:
+        #     return
+        if index in self.rc_df.index:
             return
 
         self._append_row(index, value, new_cols)

--- a/algotrader/trading/instrument_data.py
+++ b/algotrader/trading/instrument_data.py
@@ -13,6 +13,7 @@ from algotrader.utils.logging import logger
 from algotrader.utils.market_data import get_series_id, get_frame_id
 from algotrader.utils.model import get_full_cls_name, get_cls
 from algotrader.utils.protobuf_to_dict import protobuf_to_dict
+from algotrader.app import Application
 
 
 class InstrumentDataManager(MarketDataEventHandler, Manager):
@@ -74,10 +75,12 @@ class InstrumentDataManager(MarketDataEventHandler, Manager):
                     self.store.save_trade(trade)
 
             elif self.persist_mode != PersistenceMode.Disable:
-                for series in self.__series_dict.values():
+                for series in (series for series in self.__series_dict.values()\
+                               if not series.provider_id == Application.BackTesting):
                     self.store.save_series(series.to_proto_series())
 
-                for df in self.__frame_dict.values():
+                for df in (df for df in self.__frame_dict.values()\
+                           if not df.provider_id == Application.BackTesting):
                     self.store.save_frame(df.to_proto_frame(self.app_context))
 
     def _is_realtime_persist(self):

--- a/algotrader/trading/series.py
+++ b/algotrader/trading/series.py
@@ -28,6 +28,7 @@ class Series(Subscribable, Startable, Monad, Monoid):
                  func=None,
                  parent_series_id: str = None,
                  update_mode: UpdateMode = UpdateMode.ACTIVE_SUBSCRIBE,
+                 transient=False,
                  *args,
                  **kwargs
                  ):
@@ -42,6 +43,7 @@ class Series(Subscribable, Startable, Monad, Monoid):
         self.func = func
         self.parent_series_id = parent_series_id
         self.update_mode = update_mode
+        self.transient = transient
 
     def _start(self, app_context=None):
 

--- a/config/backtest.yaml
+++ b/config/backtest.yaml
@@ -4,14 +4,15 @@ Application:
 
   clockId: "Simulation"
 
-  dataStoreId: "InMemory"
-#  dataStoreId: "Mongo"
+#  dataStoreId: "InMemory"
+  dataStoreId: "Mongo"
   persistenceMode: "Disable"
+#  persistenceMode: "RealTime"
   createDBAtStart : false
   deleteDBAtStop : false
 
-  feedId: "CSV"
-#  feedId: "PandasDB"
+#  feedId: "CSV"
+  feedId: "PandasDB"
   brokerId: "Simulator"
   portfolioId: "test"
 

--- a/config/unittest.yaml
+++ b/config/unittest.yaml
@@ -4,10 +4,10 @@ Application:
 
   clockId: "Simulation"
 
-  dataStoreId: "InMemory"
-#  dataStoreId: "Mongo"
-  persistenceMode: "Disable"
-  createDBAtStart : false
+#  dataStoreId: "InMemory"
+  dataStoreId: "Mongo"
+  persistenceMode: "RealTime"
+  createDBAtStart : True
   deleteDBAtStop : false
 
   feedId: "CSV"
@@ -36,7 +36,7 @@ DataStore:
     port: 27017
     username:
     password:
-    dbname: "algotrader"
+    dbname: "test"
 
   InMemory:
     file: "../../data/algotrader_db.p"

--- a/release.txt
+++ b/release.txt
@@ -8,3 +8,6 @@
 - Rollback all 13-Nov-2017's changes. Now a new flag is introduced for series and dataframe as transient. When it is transient,
 it will never be serialized and stored to the database. It is particular useful when we replay those historical market data
 in backtesting, so we will use a transient series to store it during backtest.
+12-Dec-2017:
+- The transient flag is not just used in instrument data manager when getting series and df. We also introduce this transient flag
+into the series and df.

--- a/release.txt
+++ b/release.txt
@@ -4,3 +4,5 @@
 - In instrument data manager, on_bar, the provider id will depends on app context's application type (backtest / live trading),
  instead of bar's source provider id. In the coming version, the BackTesting as provider_id series/frame will be deleted and
  not serialized.
+14-Nov-2017:
+- Those frame/series with BackTesting in provider_id will not be serialized.

--- a/release.txt
+++ b/release.txt
@@ -4,3 +4,7 @@
 - In instrument data manager, on_bar, the provider id will depends on app context's application type (backtest / live trading),
  instead of bar's source provider id. In the coming version, the BackTesting as provider_id series/frame will be deleted and
  not serialized.
+7-Dec-2017:
+- Rollback all 13-Nov-2017's changes. Now a new flag is introduced for series and dataframe as transient. When it is transient,
+it will never be serialized and stored to the database. It is particular useful when we replay those historical market data
+in backtesting, so we will use a transient series to store it during backtest.

--- a/release.txt
+++ b/release.txt
@@ -1,2 +1,6 @@
 31-Oct-2017:
 - Fix the subscription when multiple instruments
+13-Nov-2017:
+- In instrument data manager, on_bar, the provider id will depends on app context's application type (backtest / live trading),
+ instead of bar's source provider id. In the coming version, the BackTesting as provider_id series/frame will be deleted and
+ not serialized.

--- a/tests/test_persistence_indicator.py
+++ b/tests/test_persistence_indicator.py
@@ -26,11 +26,12 @@ class IndicatorPersistenceTest(TestCase):
 
     def create_app_context(self, conf):
         return ApplicationContext(config=Config(
-            load_from_yaml("../config/backtest.yaml"),
+            load_from_yaml("../config/unittest.yaml"),
             load_from_yaml("../config/down2%.yaml"),
             test_override,
             {
                 "Application": {
+                    "dataStoreId": "Mongo",
                     "ceateAtStart": True,
                     "deleteDBAtStop": False,
                     "persistenceMode": "RealTime"

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -119,9 +119,9 @@ class SeriesTest(TestCase):
     def test_empty_series_ctor(self):
         try:
             series = Series()
-            self.assertIsNone(series.inst_id)
-            self.assertIsNone(series.df_id)
-            self.assertIsNone(series.col_id)
+            self.assertEqual(series.inst_id, '')
+            self.assertEqual(series.df_id, '')
+            self.assertEqual(series.col_id, '')
             self.assertEqual(np.float64, series.dtype)
         except Exception:
             self.fail("series ctor raised ExceptionType unexpectedly!")

--- a/todo.txt
+++ b/todo.txt
@@ -1,3 +1,5 @@
+For some reason, the close series of HSI before the pandas_db feed load it, so when we load there we have a NAN series
+
 ### Dataframe / Series
 - to and from pandas
 - to and from Protobuf


### PR DESCRIPTION
When we replay the market data from series store in DB, in the on_bar of the instrument data manager, we will add the bar to the fictitious series with provider id "backtesting" such that the strategy will have a series that is started fresh and see update event from bar. 

Once the backtesting is done, this BackTesting series / frame will not serialized to the db as the original series is already there.